### PR TITLE
Added declared type values as 3rd argument to callbacks

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <queue>
 #include <vector>
+#include <map>
 
 #include <sqlite3.h>
 #include "nan.h"
@@ -68,6 +69,7 @@ namespace Values {
 
 typedef std::vector<Values::Field*> Row;
 typedef std::vector<Row*> Rows;
+typedef std::map<std::string,std::string> Decltypes;
 typedef Row Parameters;
 
 
@@ -104,6 +106,7 @@ public:
         RowBaton(Statement* stmt_, Handle<Function> cb_) :
             Baton(stmt_, cb_) {}
         Row row;
+        Decltypes types;
     };
 
     struct RunBaton : Baton {
@@ -117,6 +120,7 @@ public:
         RowsBaton(Statement* stmt_, Handle<Function> cb_) :
             Baton(stmt_, cb_) {}
         Rows rows;
+        Decltypes types;
     };
 
     struct Async;
@@ -161,6 +165,7 @@ public:
         uv_async_t watcher;
         Statement* stmt;
         Rows data;
+        Decltypes types;
         NODE_SQLITE3_MUTEX_t;
         bool completed;
         int retrieved;

--- a/test/decltypes.js
+++ b/test/decltypes.js
@@ -1,0 +1,53 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+
+describe('declared types', function() {
+    var db;
+    before(function(done) {
+        db = new sqlite3.Database(':memory:', done);
+    });
+
+    it('should create the table', function(done) {
+        db.run('CREATE TABLE foo (txt TEXT, num INT, date DATETIME)', done);
+    });
+
+    it('should retrieve declared types in all', function(done) {
+        db.all('SELECT *, 1 as untyped FROM foo', function(err, rows, decltypes) {
+            if (err) throw err;
+            assert.deepEqual(decltypes, {
+                num: 'INT',
+                txt: 'TEXT',
+                date: 'DATETIME'
+            });
+            done();
+        });
+    });
+
+    it('should retrieve declared types in get', function(done) {
+        db.get('SELECT *, 1 as untyped FROM foo', function(err, row, decltypes) {
+            if (err) throw err;
+            assert.deepEqual(decltypes, {
+                num: 'INT',
+                txt: 'TEXT',
+                date: 'DATETIME'
+            });
+            done();
+        });
+    });
+
+    it('should insert a value', function(done) {
+        db.run('INSERT INTO foo VALUES("hello world", 1, "2015-01-01")', done);
+    });
+
+    it('should retrieve declared types in each', function(done) {
+        db.each('SELECT *, 1 as untyped FROM foo', function(err, rows, decltypes) {
+            if (err) throw err;
+            assert.deepEqual(decltypes, {
+                num: 'INT',
+                txt: 'TEXT',
+                date: 'DATETIME'
+            });
+            done();
+        });
+    });
+});


### PR DESCRIPTION
This fully addresses #376.

I think this is a really valuable feature that many of the other database bindings provide. This should be a relatively straightforward change of simply passing an object containing the column names as properties and their declared types as the values.

The only note on backwards compatibility is that we're now passing 3 arguments to callbacks. If someone used an assertion/guard for `arguments.length === 2`, then their code would break. I doubt a large percentage of code does this, and the documentation doesn't really indicate that more arguments would never be passed.
