### PR TITLE
npm install can't find node-pre-gyp.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     },
     "scripts": {
         "prepublish":"npm ls",
-        "install": "node-pre-gyp install --fallback-to-build",
+        "install": "node_modules/node-pre-gyp/bin/node-pre-gyp install --fallback-to-build",
         "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 480000"
     },


### PR DESCRIPTION
`node-pre-gyp` was installed properly but there was no path to the actual script.

When building in a cross-tool environment the install choked.

-Dale
