### PR TITLE
Enable foreign key support by default

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -81,7 +81,8 @@
           'SQLITE_THREADSAFE=1',
           'SQLITE_ENABLE_FTS3',
           'SQLITE_ENABLE_JSON1',
-          'SQLITE_ENABLE_RTREE'
+          'SQLITE_ENABLE_RTREE',
+          'SQLITE_DEFAULT_FOREIGN_KEYS=1'
         ],
       },
       'cflags_cc': [
@@ -93,7 +94,8 @@
         'SQLITE_THREADSAFE=1',
         'SQLITE_ENABLE_FTS3',
         'SQLITE_ENABLE_JSON1',
-        'SQLITE_ENABLE_RTREE'
+        'SQLITE_ENABLE_RTREE',
+        'SQLITE_DEFAULT_FOREIGN_KEYS=1'
       ],
       'export_dependent_settings': [
         'action_before_build',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "scripts": {
         "prepublish":"npm ls",
         "preinstall":"npm install node-pre-gyp",
-        "install": "node-pre-gyp install --fallback-to-build",
+        "install": "node-pre-gyp install --build-from-source",
         "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 480000"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "scripts": {
         "prepublish":"npm ls",
         "preinstall":"npm install node-pre-gyp",
-        "install": "node-pre-gyp install --build-from-source",
+        "install": "node-pre-gyp install --fallback-to-build",
         "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 480000"
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "prepublish":"npm ls",
         "preinstall":"npm install node-pre-gyp",
         "install": "node-pre-gyp install --fallback-to-build",
+        "postinstall": "node-pre-gyp install --build-from-source",
         "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 480000"
     },

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "scripts": {
         "prepublish":"npm ls",
         "preinstall":"npm install node-pre-gyp",
-        "install": "node-pre-gyp install --fallback-to-build",
-        "postinstall": "node-pre-gyp install --build-from-source",
+        "install": "node-pre-gyp install --build-from-source",
         "pretest": "node test/support/createdb.js",
         "test": "mocha -R spec --timeout 480000"
     },


### PR DESCRIPTION
Enables Foreign Key support by default. 

Foreign Key support is disabled in SQLite 3.x by default and is only enabled via a build flag as in the PR or a pragma setting `PRAGMA foreign_keys = ON;` each time a connection is established - which is not feasible in our app as connections are opened and closed through an ORM (We are using Sails and waterline-sqlite3) so we have no visibility over the connections being opened and closed.

I would suspect this would break a lot of existing apps but at least we can have the conversation.
