### PR TITLE
Add TRY_CATCH_CALL function check and remove Nan::MakeCallback

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -107,7 +107,7 @@ const char* sqlite_authorizer_string(int type);
 
 #define TRY_CATCH_CALL(context, callback, argc, argv)                          \
     if(!callback.IsEmpty() && callback->IsFunction()){                         \
-        (callback)->Call((context), (argc), (argv));                           \
+        Nan::Call((callback), (context), (argc), (argv));                      \
     }
 
 #define WORK_DEFINITION(name)                                                  \

--- a/src/macros.h
+++ b/src/macros.h
@@ -106,7 +106,9 @@ const char* sqlite_authorizer_string(int type);
     );
 
 #define TRY_CATCH_CALL(context, callback, argc, argv)                          \
-    Nan::MakeCallback((context), (callback), (argc), (argv))
+    if(!callback.IsEmpty() && callback->IsFunction()){                         \
+        (callback)->Call((context), (argc), (argv));                           \
+    }
 
 #define WORK_DEFINITION(name)                                                  \
     static NAN_METHOD(name);                                                   \


### PR DESCRIPTION
Signed-off-by: Eugene Bolshakov pub@relvarsoft.com

This patch fixes 2 issues:
1. There is no check for a callback function presence in TRY_CATCH_CALL
2. Remove Nan::MakeCallback due to https://github.com/nodejs/nan/issues/284 and use Nan::Call
