### PR TITLE
test to capture UPDATE ... LIMIT functionality

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -81,7 +81,8 @@
           'SQLITE_THREADSAFE=1',
           'SQLITE_ENABLE_FTS3',
           'SQLITE_ENABLE_JSON1',
-          'SQLITE_ENABLE_RTREE'
+          'SQLITE_ENABLE_RTREE',
+          'SQLITE_ENABLE_UPDATE_DELETE_LIMIT'
         ],
       },
       'cflags_cc': [
@@ -93,7 +94,8 @@
         'SQLITE_THREADSAFE=1',
         'SQLITE_ENABLE_FTS3',
         'SQLITE_ENABLE_JSON1',
-        'SQLITE_ENABLE_RTREE'
+        'SQLITE_ENABLE_RTREE',
+        'SQLITE_ENABLE_UPDATE_DELETE_LIMIT'
       ],
       'export_dependent_settings': [
         'action_before_build',

--- a/test/build_feature_flags.js
+++ b/test/build_feature_flags.js
@@ -1,0 +1,23 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+var fs = require('fs');
+
+describe('build feature flags', function() {
+  var db;
+
+  beforeEach(function(done) {
+    db = new sqlite3.Database(':memory:');
+    db.run("CREATE TABLE waffles (id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, number INTEGER)", done);
+  });
+
+  it('allows UPDATE ... limit', function(done) {
+    var sql = "UPDATE waffles SET number = number - ? WHERE number >= ? ORDER BY id ASC LIMIT 1";
+
+    db.run(sql, [1,1], function(err) {
+      if (err) throw err;
+
+      done();
+    });
+  });
+});
+


### PR DESCRIPTION
Non-working due to sqlite (apparently) having other requirements around
the lemon parser generator in order to enable this feature.

See #306 
