### PR TITLE
port to be used on z/OS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,11 @@
   "targets": [
     {
       "target_name": "<(module_name)",
+      'conditions': [
+        ['OS!="os390"', {
+          'cflags': [ '-include ../src/gcc-preinclude.h' ],
+        }],
+      ],
       "include_dirs": ["<!(node -e \"require('nan')\")"],
       "conditions": [
         ["sqlite != 'internal'", {
@@ -31,7 +36,6 @@
         }
         ]
       ],
-      "cflags": [ "-include ../src/gcc-preinclude.h" ],
       "sources": [
         "src/database.cc",
         "src/node_sqlite3.cc",

--- a/deps/extract.py
+++ b/deps/extract.py
@@ -1,9 +1,20 @@
 import sys
 import tarfile
 import os
+import platform
 
 tarball = os.path.abspath(sys.argv[1])
 dirname = os.path.abspath(sys.argv[2])
-tfile = tarfile.open(tarball,'r:gz');
-tfile.extractall(dirname)
+if platform.system() == 'OS/390':
+  import tempfile 
+  tempfile = tempfile.NamedTemporaryFile()
+  cmdtype = ("cd %s"
+             " && (iconv -f IBM-1047 -t ISO8859-1 %s | gunzip -c > %s)"
+             " && pax -ofrom=ISO8859-1,to=IBM-1047 -rf %s")
+  cmd = cmdtype % (dirname, tarball, tempfile.name, tempfile.name)
+  os.system(cmd)
+else:
+  tfile = tarfile.open(tarball,'r:gz');
+  tfile.extractall(dirname)
 sys.exit(0)
+

--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -2,9 +2,16 @@
   'includes': [ 'common-sqlite.gypi' ],
   'target_defaults': {
     'default_configuration': 'Release',
-    'cflags':[
-      '-std=c99'
-    ],
+    'conditions':[
+      'OS=="os390"', {
+        'cflags':[
+          '-qlanglvl=stdc99'
+        ]
+      }, {
+        'cflags':[
+          '-std=c99'
+        ]
+    }],
     'configurations': {
       'Debug': {
         'defines': [ 'DEBUG', '_DEBUG' ],
@@ -71,7 +78,11 @@
       'dependencies': [
         'action_before_build'
       ],
-      'cflags': [ '-include ../src/gcc-preinclude.h' ],
+      'conditions': [
+        ['OS!="os390"', {
+          'cflags': [ '-include ../src/gcc-preinclude.h' ],
+        }],
+      ],
       'sources': [
         '<(SHARED_INTERMEDIATE_DIR)/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
       ],

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "git://github.com/mapbox/node-sqlite3.git"
   },
   "dependencies": {
-    "nan": "~2.4.0",
+    "nan": "^2.5.0",
     "node-pre-gyp": "~0.6.31"
   },
   "bundledDependencies": [		


### PR DESCRIPTION
Use nan 2.5.0
Use xlc options instead of gcc options.
Avoid use of python tar functionality. Use shell instead.