### PR TITLE
Adding promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ db.close();
  - Extensive [debugging support](https://github.com/mapbox/node-sqlite3/wiki/Debugging)
  - [Query serialization](https://github.com/mapbox/node-sqlite3/wiki/Control-Flow) API
  - [Extension support](https://github.com/mapbox/node-sqlite3/wiki/Extensions)
+ - Promise support
  - Big test suite
  - Written in modern C++ and tested for memory leaks
  - Bundles Sqlite3 3.15.0 as a fallback if the installing system doesn't include SQLite
@@ -180,6 +181,7 @@ In sqlite3's directory (where its `package.json` resides) run the following:
 * [Audrius Kažukauskas](https://github.com/audriusk)
 * [Johannes Schauer](https://github.com/pyneo)
 * [Mithgol](https://github.com/Mithgol)
+* [Aminadav Glickshtein](https://github.com/aminadav)
 
 # Acknowledgments
 

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -188,4 +188,4 @@ sqlite3.verbose = function() {
     return this;
 };
 
-Database=Promise.promisifyAll(Database.prototype)
+Database.prototype=Promise.promisifyAll(Database.prototype)

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -4,6 +4,7 @@ var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json
 var binding = require(binding_path);
 var sqlite3 = module.exports = exports = binding;
 var EventEmitter = require('events').EventEmitter;
+var Promise=require('bluebird')
 
 function normalizeMethod (fn) {
     return function (sql) {
@@ -186,3 +187,5 @@ sqlite3.verbose = function() {
 
     return this;
 };
+
+Database=Promise.promisifyAll(Database.prototype)

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
     "url": "git://github.com/mapbox/node-sqlite3.git"
   },
   "dependencies": {
+    "bluebird": "^3.4.7",
     "nan": "~2.4.0",
     "node-pre-gyp": "~0.6.31"
   },
-  "bundledDependencies": [		
-      "node-pre-gyp"		
+  "bundledDependencies": [
+    "node-pre-gyp"
   ],
   "devDependencies": {
     "aws-sdk": "2.x",


### PR DESCRIPTION
See this code for example:
```
init() 

async function init(){
	var db=new sqlite3.Database('candelete.db')
	await db.runAsync('create table abc (c tinyint)')
	await db.runAsync('insert into abc values (3)')
	var result = await db.allAsync('select * from abc')
	console.log(result)  // {[a:3]}
}
```