### PR TITLE
Fix addListener('insert/update/delete') events

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -146,7 +146,7 @@ Statement.prototype.map = function() {
 
 var isVerbose = false;
 
-var supportedEvents = [ 'trace', 'profile', 'insert', 'update', 'delete' ];
+var supportedEvents = [ 'trace', 'profile', 'change'];
 
 Database.prototype.addListener = Database.prototype.on = function(type) {
     var val = EventEmitter.prototype.addListener.apply(this, arguments);

--- a/src/database.cc
+++ b/src/database.cc
@@ -335,6 +335,15 @@ NAN_METHOD(Database::Configure) {
         Baton* baton = new Baton(db, handle);
         db->Schedule(RegisterProfileCallback, baton);
     }
+    else if (
+        Nan::Equals(info[0], Nan::New("insert").ToLocalChecked()).FromJust() ||
+        Nan::Equals(info[0], Nan::New("update").ToLocalChecked()).FromJust() ||
+        Nan::Equals(info[0], Nan::New("delete").ToLocalChecked()).FromJust()
+    ) {
+        Local<Function> handle;
+        Baton* baton = new Baton(db, handle);
+        db->Schedule(RegisterUpdateCallback, baton);
+    }
     else if (Nan::Equals(info[0], Nan::New("busyTimeout").ToLocalChecked()).FromJust()) {
         if (!info[1]->IsInt32()) {
             return Nan::ThrowTypeError("Value must be an integer");

--- a/src/database.cc
+++ b/src/database.cc
@@ -336,9 +336,7 @@ NAN_METHOD(Database::Configure) {
         db->Schedule(RegisterProfileCallback, baton);
     }
     else if (
-        Nan::Equals(info[0], Nan::New("insert").ToLocalChecked()).FromJust() ||
-        Nan::Equals(info[0], Nan::New("update").ToLocalChecked()).FromJust() ||
-        Nan::Equals(info[0], Nan::New("delete").ToLocalChecked()).FromJust()
+        Nan::Equals(info[0], Nan::New("change").ToLocalChecked()).FromJust()
     ) {
         Local<Function> handle;
         Baton* baton = new Baton(db, handle);
@@ -508,12 +506,13 @@ void Database::UpdateCallback(Database *db, UpdateInfo* info) {
     Nan::HandleScope scope;
 
     Local<Value> argv[] = {
+        Nan::New("change").ToLocalChecked(),
         Nan::New(sqlite_authorizer_string(info->type)).ToLocalChecked(),
         Nan::New(info->database.c_str()).ToLocalChecked(),
         Nan::New(info->table.c_str()).ToLocalChecked(),
         Nan::New<Number>(info->rowid),
     };
-    EMIT_EVENT(db->handle(), 4, argv);
+    EMIT_EVENT(db->handle(), 5, argv);
     delete info;
 }
 


### PR DESCRIPTION
The `addListener('insert /update/delete') API throw 
```
Error: update is not a valid configuration option
    at Database.addListener.Database.on (D:\dvp\study_stack\cloudfs\node_modules\sqlite3\lib\sqlite3.js:154:14)
    at SQLITE.on (D:\dvp\study_stack\cloudfs\libs\sql.js:74:15)
    at test.run (D:\dvp\study_stack\cloudfs\test.js:12:14)
    at <anonymous> Error: update is not a valid configuration option
    at Database.addListener.Database.on (D:\dvp\study_stack\cloudfs\node_modules\sqlite3\lib\sqlite3.js:154:14)
    at SQLITE.on (D:\dvp\study_stack\cloudfs\libs\sql.js:74:15)
    at test.run (D:\dvp\study_stack\cloudfs\test.js:12:14)
    at <anonymous>
```

The following adjustement in Database::Configure make it work !