### PR TITLE
Use util.promisify.custom to improve promisify support of db.run()

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -79,19 +79,21 @@ Database.prototype.run = normalizeMethod(function(statement, params) {
     return this;
 });
 if (typeof util.promisify === 'function') {
-    Database.prototype.run[util.promisify.custom] = function() {
-        var runThis = this;
-        var runArguments = arguments;
+    function promisifyRun() {
+        var thisForRun = this;
+        var argumentsForRun = arguments;
         return new Promise(function(resolve, reject) {
             Array.prototype.push.call(
-                runArguments,
+                argumentsForRun,
                 function(err) {
                     err ? reject(err) : resolve(this);
                 }
             );
-            Database.prototype.run.apply(runThis, runArguments);
+            thisForRun.run.apply(thisForRun, argumentsForRun);
         });
-    };
+    }
+    Database.prototype.run[util.promisify.custom] = promisifyRun;
+    Statement.prototype.run[util.promisify.custom] = promisifyRun;
 }
 
 // Database#get(sql, [bind1, bind2, ...], [callback])

--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -4,6 +4,7 @@ var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json
 var binding = require(binding_path);
 var sqlite3 = module.exports = exports = binding;
 var EventEmitter = require('events').EventEmitter;
+var util = require('util');
 
 function normalizeMethod (fn) {
     return function (sql) {
@@ -77,6 +78,21 @@ Database.prototype.run = normalizeMethod(function(statement, params) {
     statement.run.apply(statement, params).finalize();
     return this;
 });
+if (typeof util.promisify === 'function') {
+    Database.prototype.run[util.promisify.custom] = function() {
+        var runThis = this;
+        var runArguments = arguments;
+        return new Promise(function(resolve, reject) {
+            Array.prototype.push.call(
+                runArguments,
+                function(err) {
+                    err ? reject(err) : resolve(this);
+                }
+            );
+            Database.prototype.run.apply(runThis, runArguments);
+        });
+    };
+}
 
 // Database#get(sql, [bind1, bind2, ...], [callback])
 Database.prototype.get = normalizeMethod(function(statement, params) {

--- a/test/promisify_run.test.js
+++ b/test/promisify_run.test.js
@@ -11,46 +11,31 @@ if (typeof util.promisify === 'function') {
             promisifyedDbRun = util.promisify(db.run).bind(db);
         });
 
-        it('should create the table', function(done) {
-            promisifyedDbRun("CREATE TABLE foo (txt TEXT, num INT)")
+        it('should create the table', function() {
+            return promisifyedDbRun("CREATE TABLE foo (txt TEXT, num INT)")
                 .then(function(result) {
-                    assert.deepEqual(result, {
-                        changes: 0,
-                        lastID: 0,
-                        sql: 'CREATE TABLE foo (txt TEXT, num INT)'
-                    });
-                    done();
-                })
-                .catch(done);
+                    assert.equal(result.changes, 0);
+                    assert.equal(result.lastID, 0);
+                });
         });
 
-        it('should insert a value without placeholders', function(done) {
-            promisifyedDbRun("INSERT INTO foo VALUES('Lorem Ipsum', 1)")
+        it('should insert a value without placeholders', function() {
+            return promisifyedDbRun("INSERT INTO foo VALUES('Lorem Ipsum', 1)")
                 .then(function(result) {
-                    assert.deepEqual(result, {
-                        changes: 1,
-                        lastID: 1,
-                        sql: "INSERT INTO foo VALUES('Lorem Ipsum', 1)"
-                    });
-                    done();
-                })
-                .catch(done);
+                    assert.equal(result.changes, 1);
+                    assert.equal(result.lastID, 1);
+                });
         });
 
-        it('should update a value with placeholders', function(done) {
-            promisifyedDbRun("UPDATE foo SET txt = $text WHERE num = $id", {
+        it('should update a value with placeholders', function() {
+            return promisifyedDbRun("UPDATE foo SET txt = $text WHERE num = $id", {
                 $id: 1,
                 $text: "Dolor Sit Amet"
             })
                 .then(function(result) {
-                    assert.deepEqual(result, {
-                        changes: 1,
-                        lastID: 1,
-                        sql: 'UPDATE foo SET txt = $text WHERE num = $id'
-                    });
-                    done();
-                })
-                .catch(done);
+                    assert.equal(result.changes, 1);
+                    assert.equal(result.lastID, 1);
+                });
         });
 
         it('should retrieve values', function(done) {

--- a/test/promisify_run.test.js
+++ b/test/promisify_run.test.js
@@ -38,12 +38,27 @@ if (typeof util.promisify === 'function') {
                 });
         });
 
+        it('should also work with statement', function() {
+            var stmt = db.prepare("INSERT INTO foo VALUES($text, $id)");
+            var promisifyedStatementRun = util.promisify(stmt.run).bind(stmt);
+            return promisifyedStatementRun({
+                $id: 2,
+                $text: "Consectetur Adipiscing Elit"
+            })
+                .then(function(result) {
+                    assert.equal(result.changes, 1);
+                    assert.equal(result.lastID, 2);
+                });
+        });
+
         it('should retrieve values', function(done) {
             db.all("SELECT txt, num FROM foo", function(err, rows) {
                 if (err) throw err;
                 assert.equal(rows[0].txt, "Dolor Sit Amet");
                 assert.equal(rows[0].num, 1);
-                assert.equal(rows.length, 1);
+                assert.equal(rows[1].txt, "Consectetur Adipiscing Elit");
+                assert.equal(rows[1].num, 2);
+                assert.equal(rows.length, 2);
                 done();
             });
         });

--- a/test/promisify_run.test.js
+++ b/test/promisify_run.test.js
@@ -1,0 +1,66 @@
+var sqlite3 = require('..');
+var assert = require('assert');
+var util = require('util');
+
+if (typeof util.promisify === 'function') {
+    describe('promisify run', function() {
+        var db;
+        var promisifyedDbRun;
+        before(function(done) {
+            db = new sqlite3.Database(':memory:', done);
+            promisifyedDbRun = util.promisify(db.run).bind(db);
+        });
+
+        it('should create the table', function(done) {
+            promisifyedDbRun("CREATE TABLE foo (txt TEXT, num INT)")
+                .then(function(result) {
+                    assert.deepEqual(result, {
+                        changes: 0,
+                        lastID: 0,
+                        sql: 'CREATE TABLE foo (txt TEXT, num INT)'
+                    });
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should insert a value without placeholders', function(done) {
+            promisifyedDbRun("INSERT INTO foo VALUES('Lorem Ipsum', 1)")
+                .then(function(result) {
+                    assert.deepEqual(result, {
+                        changes: 1,
+                        lastID: 1,
+                        sql: "INSERT INTO foo VALUES('Lorem Ipsum', 1)"
+                    });
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should update a value with placeholders', function(done) {
+            promisifyedDbRun("UPDATE foo SET txt = $text WHERE num = $id", {
+                $id: 1,
+                $text: "Dolor Sit Amet"
+            })
+                .then(function(result) {
+                    assert.deepEqual(result, {
+                        changes: 1,
+                        lastID: 1,
+                        sql: 'UPDATE foo SET txt = $text WHERE num = $id'
+                    });
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('should retrieve values', function(done) {
+            db.all("SELECT txt, num FROM foo", function(err, rows) {
+                if (err) throw err;
+                assert.equal(rows[0].txt, "Dolor Sit Amet");
+                assert.equal(rows[0].num, 1);
+                assert.equal(rows.length, 1);
+                done();
+            });
+        });
+    });
+}


### PR DESCRIPTION
Fixes #658

Currently, promisifying `db.run()` results in a loss of information of `lastID` and `changes`.
In this PR, I customized the promisification of `db.run()` using `util.promisify.custom` to solve the problem.