### PR TITLE
prebuilt: add electron 9.0, 8.3 and 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,22 @@ matrix:
      # electron Linux
      - os: linux
        compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="9.0.0"
+       dist: trusty
+       addons:
+         apt:
+           sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+           packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="8.3.0"
+       dist: trusty
+       addons:
+         apt:
+           sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+           packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+     - os: linux
+       compiler: clang
        env: NODE_VERSION="12" ELECTRON_VERSION="8.2.0"
        dist: trusty
        addons:
@@ -87,6 +103,14 @@ matrix:
          apt:
             sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
             packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
+     - os: linux
+       compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="7.3.0"
+       dist: trusty
+       addons:
+         apt:
+           sources: [ 'ubuntu-toolchain-r-test','llvm-toolchain-precise-3.5', 'gcc-multilib', 'g++-multilib', 'libsqlite3-dev:i386' ]
+           packages: [ 'clang-3.5', 'libstdc++-4.9-dev']
      - os: linux
        compiler: clang
        env: NODE_VERSION="12" ELECTRON_VERSION="7.2.0"
@@ -130,6 +154,12 @@ matrix:
      # electron MacOs
      - os: osx
        compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="9.0.0"
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="8.3.0"
+     - os: osx
+       compiler: clang
        env: NODE_VERSION="12" ELECTRON_VERSION="8.2.0"
      - os: osx
        compiler: clang
@@ -137,6 +167,9 @@ matrix:
      - os: osx
        compiler: clang
        env: NODE_VERSION="12" ELECTRON_VERSION="8.0.0"
+     - os: osx
+       compiler: clang
+       env: NODE_VERSION="12" ELECTRON_VERSION="7.3.0"
      - os: osx
        compiler: clang
        env: NODE_VERSION="12" ELECTRON_VERSION="7.2.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,26 @@ environment:
     - nodejs_version: 12
       platform: x64
       NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 9.0.0
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
+    - nodejs_version: 12
+      platform: x86
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 9.0.0
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
+    - nodejs_version: 12
+      platform: x64
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 8.3.0
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
+    - nodejs_version: 12
+      platform: x86
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 8.3.0
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
+    - nodejs_version: 12
+      platform: x64
+      NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 8.2.0
       TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
@@ -46,6 +66,16 @@ environment:
       platform: x86
       NODE_RUNTIME: electron
       NODE_RUNTIME_VERSION: 8.0.0
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
+    - nodejs_version: 12
+      platform: x64
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 7.3.0
+      TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
+    - nodejs_version: 12
+      platform: x86
+      NODE_RUNTIME: electron
+      NODE_RUNTIME_VERSION: 7.3.0
       TOOLSET_ARGS: --dist-url=https://electronjs.org/headers
     - nodejs_version: 12
       platform: x64


### PR DESCRIPTION
https://github.com/electron/electron/releases/tag/v9.0.0
https://github.com/electron/electron/releases/tag/v8.3.0
https://github.com/electron/electron/releases/tag/v7.3.0

I don't test with new electron version.
Do you wish to continue to support prebuilt for Electron v6?