### PR TITLE
automated arm/v7 and arm64 builds for alpine and linux built using docker buildx and github actions

### DIFF
--- a/.github/workflows/build-arm-bindings.yml
+++ b/.github/workflows/build-arm-bindings.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nodeVersion: [11, 12, 13, 14]
+        nodeVersion: [10, 11, 12, 13, 14]
         platform: ["linux", "alpine"]
         arch: [linux/arm/v7, linux/arm64]
         include:

--- a/.github/workflows/build-arm-bindings.yml
+++ b/.github/workflows/build-arm-bindings.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nodeVersion: [10, 11, 12, 13, 14]
+        nodeVersion: [10, 11, 12, 13, 14, 15, 16]
         platform: ["linux", "alpine"]
         arch: [linux/arm/v7, linux/arm64]
         include:

--- a/.github/workflows/build-arm-bindings.yml
+++ b/.github/workflows/build-arm-bindings.yml
@@ -2,6 +2,8 @@ name: Build ARM bindings
 
 on:
   push:
+    tags:
+      - "v*"
 
 jobs:
   build:

--- a/.github/workflows/build-arm-bindings.yml
+++ b/.github/workflows/build-arm-bindings.yml
@@ -1,0 +1,55 @@
+name: Build ARM bindings
+
+on:
+  push:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nodeVersion: [11, 12, 13, 14]
+        platform: ["linux", "alpine"]
+        arch: [linux/arm/v7, linux/arm64]
+        include:
+          - platform: "linux"
+            variant: "stretch"
+          - platform: "alpine"
+            variant: "alpine"
+
+          - arch: linux/arm/v7
+            archShort: armv7
+          - arch: linux/arm64
+            archShort: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+          qemu-version: latest
+      - name: Build and Push
+        run: |
+          docker buildx build \
+            --file BinaryBuilder.Dockerfile \
+            --load \
+            --tag sqlite-builder \
+            --platform ${{ matrix.arch }} \
+            --no-cache \
+            --build-arg NODE_VERSION=${{ matrix.nodeVersion }} \
+            --build-arg VARIANT=${{ matrix.variant }} \
+            --build-arg AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+            --build-arg AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            .
+          CONTAINER_ID=$(docker create -it sqlite-builder)
+          docker cp $CONTAINER_ID:/usr/src/build/build/ ./build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: node${{ matrix.nodeVersion }}-${{ matrix.platform }}-${{ matrix.archShort }}
+          path: "./build/"

--- a/BinaryBuilder.Dockerfile
+++ b/BinaryBuilder.Dockerfile
@@ -1,0 +1,19 @@
+ARG NODE_VERSION=12
+ARG VARIANT=stretch
+FROM node:$NODE_VERSION-$VARIANT
+
+ARG VARIANT
+ARG AWS_ACCESS_KEY_ID=SKIP
+ARG AWS_SECRET_ACCESS_KEY=SKIP
+
+RUN if [ "$VARIANT" = "alpine" ] ; then apk add make g++ python ; fi
+
+WORKDIR /usr/src/build
+
+COPY . .
+RUN npm install --ignore-scripts
+RUN npx node-pre-gyp install --build-from-source
+RUN npx node-pre-gyp package
+RUN if [ "$AWS_ACCESS_KEY_ID" = "SKIP" ] || [ "$AWS_SECRET_ACCESS_KEY" = "SKIP" ] ; then echo "SKIP S3 PUBLISH" ; else npx node-pre-gyp publish ; fi
+
+CMD ["sh"]

--- a/BinaryBuilder.Dockerfile
+++ b/BinaryBuilder.Dockerfile
@@ -13,6 +13,7 @@ WORKDIR /usr/src/build
 COPY . .
 RUN npm install --ignore-scripts
 RUN npx node-pre-gyp install --build-from-source
+RUN npm run test
 RUN npx node-pre-gyp package
 RUN if [ "$AWS_ACCESS_KEY_ID" = "SKIP" ] || [ "$AWS_SECRET_ACCESS_KEY" = "SKIP" ] ; then echo "SKIP S3 PUBLISH" ; else npx node-pre-gyp publish ; fi
 


### PR DESCRIPTION
This pull request adds a GitHub action that uses docker buildx for generating binaries for the following platforms.

- node16-linux-armv7
- node16-linux-arm64
- node16-alpine-armv7
- node16-alpine-arm64
- node15-linux-armv7
- node15-linux-arm64
- node15-alpine-armv7
- node15-alpine-arm64
- node14-linux-armv7
- node14-linux-arm64
- node14-alpine-armv7
- node14-alpine-arm64
- node13-linux-armv7
- node13-linux-arm64
- node13-alpine-armv7
- node13-alpine-arm64
- node12-linux-armv7
- node12-linux-arm64
- node12-alpine-armv7
- node12-alpine-arm64
- node11-linux-armv7
- node11-linux-arm64
- node11-alpine-armv7
- node11-alpine-arm64
- node10-linux-armv7
- node10-linux-arm64
- node10-alpine-armv7
- node10-alpine-arm64

The binaries will also be deployed by using `node-pre-gyp publish`.

An example build can be seen here: https://github.com/n1ru4l/node-sqlite3/actions

**TODO**:

- [x] Only trigger GitHub action upon pushing a tag (`e.g. v5.0.0`) 
- [ ] Enable GitHub Actions on this Repository (repository maintainer)
- [ ] Set `AWS_SECRET_ACCESS_KEY` and `AWS_SECRET_ACCESS_KEY` github secrets (repository maintainer)
