### PR TITLE
- add github-workflow to upload/save precompiled-binaries.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version:
+        # - 12.x
+        - 14.x
+        # - 16.x
+        os:
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: build
+      run: npm install --build-from-source
+    - uses: actions/upload-artifact@v2
+      with:
+        name: lib
+        path: lib
+    - name: test
+      run: npm test


### PR DESCRIPTION
this pr enhances the ci by uploading pre-compiled binaries to github-workflow.

users like me no longer need to bother with installing/updating tooling on local-machine to compile node-sqlite -- simply offload the the task to github-workflows.

![image](https://user-images.githubusercontent.com/280571/126874992-0581c0a1-f2db-4280-95b4-8aad489a336b.png)

![image](https://user-images.githubusercontent.com/280571/126875172-359bd787-7a56-4131-8e09-a822ccb384c6.png)

