### PR TITLE
Default to python3 for gyp

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -60,7 +60,7 @@
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
           ],
-          'action': ['<!(node -p "process.env.npm_config_python || \\"python\\"")','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
+          'action': ['<!(node -p "process.env.npm_config_python || \\"python3\\"")','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
         }
       ],
       'direct_dependent_settings': {


### PR DESCRIPTION
If `npm_config_python` is not set, then the build process for sqlite3 defaults to searching for `python` command. Using this command is ambiguous at best on what version of python will run, and at worst does not exist (e.g. on alpine). It is encouraged that scripts use an explicit python version (`python2` or `python3`) to ensure best compatibility with supported python platform. In this case, `python3` works perfectly, and so no reason to use the EOL `python2`.