### PR TITLE
Updated `node-gyp` to v8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha": "^9.2.2"
   },
   "peerDependencies": {
-    "node-gyp": "7.x"
+    "node-gyp": "8.x"
   },
   "peerDependenciesMeta": {
     "node-gyp": {
@@ -57,7 +57,7 @@
     }
   },
   "optionalDependencies": {
-    "node-gyp": "7.x"
+    "node-gyp": "8.x"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",


### PR DESCRIPTION
refs https://github.com/TryGhost/node-sqlite3/issues/1493
refs https://github.com/nodejs/node-gyp/pull/2474

- `node-gyp` 7.x has a minimum `tar` version of 6.0.2, which has a
  security vulnerability listed against it
- `node-gyp` 8.x updates the minimum to 6.1.2, which contains the fix
- `node-gyp` 8.x should still allow us to use Node 10, so we're good
  with Node compatibility
- it also seems to fix the `PYTHON` env variable being set, which helps
  fix the build for MacOS Monterey (coming in the next commit)