### PR TITLE
Fixed building on MacOS Monterey 12.3

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -60,7 +60,7 @@
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
           ],
-          'action': ['<!(node -p "process.env.npm_config_python || \\"python\\"")','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
+          'action': ['<!(node -p "process.env.PYTHON")','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
         }
       ],
       'direct_dependent_settings': {


### PR DESCRIPTION
refs https://github.com/nodejs/node-gyp/blob/f5fa6b86fd2847ca8c1996102f43d44f98780c4a/lib/find-python.js
refs https://github.com/TryGhost/node-sqlite3/issues/1552

- Monterey 12.3 removed Python 2, so `node-sqlite3` doesn't build because
  the v3 binary is called `python3` and therefore `python` is missing
- `node-gyp` has logic to find the python binary and stores it in the `PYTHON`
  env variable
- we should be able to switch to using that