### PR TITLE
Fixed Windows build architecture in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
         if: contains(matrix.os, 'windows')
+        with:
+          msbuild-architecture: ${{ matrix.architecture }}
 
       - name: Install dependencies
         run: yarn install --ignore-scripts


### PR DESCRIPTION
- we weren't passing the build architecture in so it would default to
  `x86`