### PR TITLE
Replaced Python extraction script with JS

### DIFF
--- a/deps/extract.js
+++ b/deps/extract.js
@@ -1,0 +1,10 @@
+const tar = require("tar");
+const path = require("path");
+const tarball = path.resolve(process.argv[2]);
+const dirname = path.resolve(process.argv[3]);
+
+tar.extract({
+    sync: true,
+    file: tarball,
+    cwd: dirname,
+});

--- a/deps/extract.py
+++ b/deps/extract.py
@@ -1,9 +1,0 @@
-import sys
-import tarfile
-import os
-
-tarball = os.path.abspath(sys.argv[1])
-dirname = os.path.abspath(sys.argv[2])
-tfile = tarfile.open(tarball,'r:gz');
-tfile.extractall(dirname)
-sys.exit(0)

--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -60,7 +60,7 @@
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/sqlite-autoconf-<@(sqlite_version)/sqlite3.c'
           ],
-          'action': ['<!(node -p "process.env.PYTHON")','./extract.py','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
+          'action': ['node','./extract.js','./sqlite-autoconf-<@(sqlite_version).tar.gz','<(SHARED_INTERMEDIATE_DIR)']
         }
       ],
       'direct_dependent_settings': {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "dependencies": {
     "@mapbox/node-pre-gyp": "^1.0.0",
-    "node-addon-api": "^4.2.0"
+    "node-addon-api": "^4.2.0",
+    "tar": "^6.1.11"
   },
   "devDependencies": {
     "eslint": "^7.32.0",


### PR DESCRIPTION
node-gyp already depends on tar, so nothing new here.

This should at least reduce some problems related to Python.