### PR TITLE
Added Node 18 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           - 15
           - 16
           - 17
+          - 18
         include:
           - os: windows-latest
             node: 16


### PR DESCRIPTION
- Node 18.0.0 has been released so we should be able to start running CI
  on it