### PR TITLE
Added Darwin ARM64 binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
             node: 16
             host: x86
             target: x86
+          - os: macos-m1
+            node: 16
+            host: arm64
+            target: arm64
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v3
@@ -48,6 +52,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.host }}
+
+      - name: Add yarn (self-hosted)
+        if: matrix.os == 'macos-m1'
+        run: npm install -g yarn
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1


### PR DESCRIPTION
Please see [this comment](https://github.com/TryGhost/node-sqlite3/pull/1594#issuecomment-1241245668):

> Hey all! 👋🏻 Whilst I would love to merge this, the generated binaries it produces get caught up with MacOS' quarantine flag, so the it requires you to remove the flag in order for it to be run, which is clearly not going to work from an end-user perspective.
>
> I can't tell if it's something I'm doing locally or whether there is some security issue I've missed.
>
> Any ideas welcome 🙂