### PR TITLE
Restored compatibility for Alpine 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,11 @@ jobs:
           - linux/arm64
         variant:
           - bullseye
-          - alpine
+          - alpine3.15
         include:
           # musl x64 builds
           - target: linux/amd64
-            variant: alpine
+            variant: alpine3.15
             node: 16
     name: ${{ matrix.variant }} (node=${{ matrix.node }}, target=${{ matrix.target }})
     steps:

--- a/tools/BinaryBuilder.Dockerfile
+++ b/tools/BinaryBuilder.Dockerfile
@@ -5,7 +5,7 @@ FROM node:$NODE_VERSION-$VARIANT
 
 ARG VARIANT
 
-RUN if [ "$VARIANT" = "alpine" ] ; then apk add build-base python3 --update-cache ; fi
+RUN if [[ "$VARIANT" =~ alpine* ]] ; then apk add build-base python3 --update-cache ; fi
 
 WORKDIR /usr/src/build
 
@@ -22,7 +22,7 @@ ENV CXXFLAGS="${CXXFLAGS:-} -include ../src/gcc-preinclude.h"
 RUN npx node-pre-gyp configure
 RUN npx node-pre-gyp build
 
-RUN if [ "$VARIANT" != "alpine" ] ; then ldd lib/binding/*/node_sqlite3.node; nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" | c++filt || true ; fi
+RUN if [[ ! "$VARIANT" =~ alpine* ]] ; then ldd lib/binding/*/node_sqlite3.node; nm lib/binding/*/node_sqlite3.node | grep "GLIBC_" | c++filt || true ; fi
 
 RUN npm run test
 RUN npx node-pre-gyp package


### PR DESCRIPTION
fixes https://github.com/TryGhost/node-sqlite3/issues/1625

- Alpine 3.16 was released in May 2022 and 5.0.9 was the first release
  since it became the default for `node16-alpine`
- compiling on Alpine 3.16 broke compatiblity for Alpine 3.15
- given we should be able to just build with 3.15 and the binaries end
  up forward-compatible, this commit reverts back to that