### PR TITLE
Added `package-lock.json` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ setup.sh
 /build-tmp-napi-v3
 /build-tmp-napi-v6
 *.tgz
+package-lock.json


### PR DESCRIPTION
Running `npm i` in the respository creates a `package-lock.json` file. As this file is not committed, it would be nice to have it in `.gitignore` to avoid the dirty repo state.﻿
