### PR TITLE
Fixed importing `sqlite3#verbose` using destructuring syntax

### DIFF
--- a/lib/sqlite3.js
+++ b/lib/sqlite3.js
@@ -203,5 +203,5 @@ sqlite3.verbose = function() {
         isVerbose = true;
     }
 
-    return this;
+    return sqlite3;
 };


### PR DESCRIPTION
sqlite3#verbose now returns sqlite3 instead of globalThis object when
bound to undefined (void 0). This enables importing verbose in
typescript using `import { verbose as sqlite3 } from "sqlite3"`. Because
typescript automatically converts import statement to
`sqlite3_1.default.verbose();`.