### PR TITLE
Fix rpath linker option when using a custom sqlite

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -25,8 +25,10 @@
             "libraries": [
                "-l<(sqlite_libname)"
             ],
-            "conditions": [ [ "OS=='linux'", {"libraries+":["-Wl,-rpath=<@(sqlite)/lib"]} ] ],
-            "conditions": [ [ "OS!='win'", {"libraries+":["-L<@(sqlite)/lib"]} ] ],
+            "conditions": [
+              [ "OS=='linux'", {"libraries+":["-Wl,-rpath=<@(sqlite)/lib"]} ],
+              [ "OS!='win'", {"libraries+":["-L<@(sqlite)/lib"]} ]
+            ],
             'msvs_settings': {
               'VCLinkerTool': {
                 'AdditionalLibraryDirectories': [


### PR DESCRIPTION
It seems that an old refactoring (~8 years) made a mistake on the way conditions are expressed in gyp. the "conditions" key cannot be set 2 times and the conditions should be all set in the "conditions" array.

The impact of this bug is that when sqlite3 is compiled against a custom sqlite3 source tree, the sqlite3 runtime keeps linking with the system sqlite3 instead of linking to the custom compiled sqlite3 library. In my case that lead to a SIGSEGV upon loading an extension.