### PR TITLE
Fixed glib compatibility by downgrading to Ubuntu 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-20.04
           - windows-latest
         host:
           - x64


### PR DESCRIPTION
fixes https://github.com/TryGhost/node-sqlite3/issues/1663

- Ubuntu 22.04 ships with a newer glibc so the prebuilt binaries end up being linked to a more recent version, removing compatibility with systems that ship with older variants
- this commit fixes that by downgrading the Ubuntu version