### PR TITLE
emnapi WebAssembly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
             node: 16
             host: arm64
             target: arm64
+          - os: ubuntu-20.04
+            node: 16
+            host: x64
+            target: wasm32
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
       - uses: actions/checkout@v3
@@ -52,6 +56,13 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           architecture: ${{ matrix.host }}
+      
+      - name: Setup Emscripten (WebAssembly)
+        if: matrix.target == 'wasm32'
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: '3.1.29'
+          actions-cache-folder: 'emsdk-cache'
 
       - name: Add yarn (self-hosted)
         if: matrix.os == 'macos-m1'
@@ -84,10 +95,20 @@ jobs:
           echo "CXXFLAGS=${CXXFLAGS:-} -include ../src/gcc-preinclude.h" >> $GITHUB_ENV
 
       - name: Configure build
+        if: matrix.target != 'wasm32'
         run: yarn node-pre-gyp configure --target_arch=${{ env.TARGET }}
+      
+      - name: Configure build (WebAssembly)
+        if: matrix.target == 'wasm32'
+        run: yarn node-pre-gyp configure --nodedir=./wasm --target_arch=${{ env.TARGET }}
 
       - name: Build binaries
+        if: matrix.target != 'wasm32'
         run: yarn node-pre-gyp build --target_arch=${{ env.TARGET }}
+      
+      - name: Build binaries (WebAssembly)
+        if: matrix.target == 'wasm32'
+        run: emmake yarn node-pre-gyp build --nodedir=./wasm --target_arch=${{ env.TARGET }}
 
       - name: Print binary info
         if: contains(matrix.os, 'ubuntu')
@@ -99,7 +120,12 @@ jobs:
           file lib/binding/napi-v*/*
 
       - name: Run tests
+        if: matrix.target != 'wasm32'
         run: yarn test
+      
+      - name: Run tests (WebAssembly)
+        if: matrix.target == 'wasm32'
+        run: yarn test --arch=wasm32
 
       - name: Package prebuilt binaries
         run: yarn node-pre-gyp package --target_arch=${{ env.TARGET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       
       - name: Run tests (WebAssembly)
         if: matrix.target == 'wasm32'
-        run: yarn test --arch=wasm32
+        run: npx --arch=wasm32 yarn test
 
       - name: Package prebuilt binaries
         run: yarn node-pre-gyp package --target_arch=${{ env.TARGET }}

--- a/lib/sqlite3-binding.js
+++ b/lib/sqlite3-binding.js
@@ -1,5 +1,9 @@
 const binary = require('@mapbox/node-pre-gyp');
 const path = require('path');
 const binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
-const binding = require(binding_path);
+let binding = require(binding_path);
+if (typeof binding === 'function') {
+    const emnapiContext = require('@tybys/emnapi-runtime').createContext();
+    binding = binding().emnapiInit({ context: emnapiContext });
+}
 module.exports = exports = binding;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "tar": "^6.1.11"
   },
   "devDependencies": {
+    "@tybys/emnapi": "^0.27.0",
+    "@tybys/emnapi-runtime": "^0.27.0",
     "eslint": "6.8.0",
     "mocha": "7.2.0",
     "node-pre-gyp-github": "1.4.4"

--- a/test/async_calls.test.js
+++ b/test/async_calls.test.js
@@ -6,6 +6,13 @@ const { createHook, executionAsyncId } = require("async_hooks");
 
 
 describe('async_hooks', function() {
+    before(function() {
+        if (process.env.npm_config_arch.includes('wasm')) {
+            // async_hooks is not supported by emnapi
+            this.skip();
+        }
+    });
+
     let db;
     let dbId;
     let asyncHook;

--- a/wasm/common.gypi
+++ b/wasm/common.gypi
@@ -1,0 +1,73 @@
+{
+  'variables': {
+    'OS': 'emscripten',
+    'napi_build_version%': '8',
+    'clang': 1,
+    'target_arch%': 'wasm32',
+    'wasm_threads%': 1,
+    'product_extension%': 'js',
+  },
+
+  'target_defaults': {
+    'type': 'executable',
+    'product_extension': '<(product_extension)',
+
+    'cflags': [
+      '-Wall',
+      '-Wextra',
+      '-Wno-unused-parameter',
+      '-sDEFAULT_TO_CXX=0',
+    ],
+    'cflags_cc': [
+      '-fno-rtti',
+      '-fno-exceptions',
+      '-std=gnu++17'
+    ],
+    'ldflags': [
+      '--js-library=<!(node -p "require(\'@tybys/emnapi\').js_library")',
+      "-sALLOW_MEMORY_GROWTH=1",
+      "-sEXPORTED_FUNCTIONS=['_malloc','_free']",
+      '-sNODEJS_CATCH_EXIT=0',
+      '-sNODEJS_CATCH_REJECTION=0',
+      '-sAUTO_JS_LIBRARIES=0',
+      '-sAUTO_NATIVE_LIBRARIES=0',
+    ],
+    'defines': [
+      '__STDC_FORMAT_MACROS',
+    ],
+    'include_dirs': [
+      '<!(node -p "require(\'@tybys/emnapi\').include")',
+    ],
+    'sources': [
+      '<!@(node -p "require(\'@tybys/emnapi\').sources.map(x => JSON.stringify(path.relative(process.cwd(), x))).join(\' \')")'
+    ],
+
+    'default_configuration': 'Release',
+    'configurations': {
+      'Debug': {
+        'defines': [ 'DEBUG', '_DEBUG' ],
+        'cflags': [ '-g', '-O0' ],
+        'ldflags': [ '-g', '-O0', '-sSAFE_HEAP=1' ],
+      },
+      'Release': {
+        'cflags': [ '-O3' ],
+        'ldflags': [ '-O3' ],
+      }
+    },
+
+    'conditions': [
+      ['target_arch == "wasm64"', {
+        'cflags': [
+          '-sMEMORY64=1',
+        ],
+        'ldflags': [
+          '-sMEMORY64=1'
+        ]
+      }],
+      ['wasm_threads == 1', {
+        'cflags': [ '-sUSE_PTHREADS=1' ],
+        'ldflags': [ '-sUSE_PTHREADS=1' ],
+      }],
+    ],
+  }
+}


### PR DESCRIPTION
I created [emnapi](https://github.com/toyobayashi/emnapi) for porting Node.js addons written in Node-API to Emscripten WebAssembly. I successfully built this project to wasm, all test cases passed except the one related to `async_hooks`, which is not supported by emnapi.

```bash
yarn node-pre-gyp configure --nodedir=./wasm --target_arch=wasm32
emmake yarn node-pre-gyp build --nodedir=./wasm --target_arch=wasm32
npx --arch=wasm32 yarn test
```

![image](https://user-images.githubusercontent.com/23353576/213753323-27b51f4e-1334-4c00-ae9e-906f640a58be.png)

