### PR TITLE
Add generic type annotations for Statement and Database get/all/each methods callback rows

### DIFF
--- a/lib/sqlite3.d.ts
+++ b/lib/sqlite3.d.ts
@@ -80,16 +80,16 @@ export class Statement extends events.EventEmitter {
     run(params: any, callback?: (this: RunResult, err: Error | null) => void): this;
     run(...params: any[]): this;
 
-    get(callback?: (err: Error | null, row?: any) => void): this;
-    get(params: any, callback?: (this: RunResult, err: Error | null, row?: any) => void): this;
+    get<T>(callback?: (err: Error | null, row?: T) => void): this;
+    get<T>(params: any, callback?: (this: RunResult, err: Error | null, row?: T) => void): this;
     get(...params: any[]): this;
 
-    all(callback?: (err: Error | null, rows: any[]) => void): this;
-    all(params: any, callback?: (this: RunResult, err: Error | null, rows: any[]) => void): this;
+    all<T>(callback?: (err: Error | null, rows: T[]) => void): this;
+    all<T>(params: any, callback?: (this: RunResult, err: Error | null, rows: T[]) => void): this;
     all(...params: any[]): this;
 
-    each(callback?: (err: Error | null, row: any) => void, complete?: (err: Error | null, count: number) => void): this;
-    each(params: any, callback?: (this: RunResult, err: Error | null, row: any) => void, complete?: (err: Error | null, count: number) => void): this;
+    each<T>(callback?: (err: Error | null, row: T) => void, complete?: (err: Error | null, count: number) => void): this;
+    each<T>(params: any, callback?: (this: RunResult, err: Error | null, row: T) => void, complete?: (err: Error | null, count: number) => void): this;
     each(...params: any[]): this;
 }
 

--- a/lib/sqlite3.d.ts
+++ b/lib/sqlite3.d.ts
@@ -103,16 +103,16 @@ export class Database extends events.EventEmitter {
     run(sql: string, params: any, callback?: (this: RunResult, err: Error | null) => void): this;
     run(sql: string, ...params: any[]): this;
 
-    get(sql: string, callback?: (this: Statement, err: Error | null, row: any) => void): this;
-    get(sql: string, params: any, callback?: (this: Statement, err: Error | null, row: any) => void): this;
+    get<T>(sql: string, callback?: (this: Statement, err: Error | null, row: T) => void): this;
+    get<T>(sql: string, params: any, callback?: (this: Statement, err: Error | null, row: T) => void): this;
     get(sql: string, ...params: any[]): this;
 
-    all(sql: string, callback?: (this: Statement, err: Error | null, rows: any[]) => void): this;
-    all(sql: string, params: any, callback?: (this: Statement, err: Error | null, rows: any[]) => void): this;
+    all<T>(sql: string, callback?: (this: Statement, err: Error | null, rows: T[]) => void): this;
+    all<T>(sql: string, params: any, callback?: (this: Statement, err: Error | null, rows: T[]) => void): this;
     all(sql: string, ...params: any[]): this;
 
-    each(sql: string, callback?: (this: Statement, err: Error | null, row: any) => void, complete?: (err: Error | null, count: number) => void): this;
-    each(sql: string, params: any, callback?: (this: Statement, err: Error | null, row: any) => void, complete?: (err: Error | null, count: number) => void): this;
+    each<T>(sql: string, callback?: (this: Statement, err: Error | null, row: T) => void, complete?: (err: Error | null, count: number) => void): this;
+    each<T>(sql: string, params: any, callback?: (this: Statement, err: Error | null, row: T) => void, complete?: (err: Error | null, count: number) => void): this;
     each(sql: string, ...params: any[]): this;
 
     exec(sql: string, callback?: (this: Statement, err: Error | null) => void): this;


### PR DESCRIPTION
# Description
Small change, but some developers enjoy working with generics over the `any` type when using TypeScript.

Added Generics type annotations for the following methods:
- `Statement.get`
- `Statement.all`
- `Statement.each`
- `Database.get`
- `Database.all`
- `Database.each`

# Backwards Compatibility
This will not break existing TypeScript code. It will still be possible to directly add type annotations to the row/rows.

# Examples:
Take into consideration the following TypeScript code:
```typescript
import sqlite3 from "sqlite3";

interface IUser {
    id: string;
    name: string;
    email: string;
}

const db = new sqlite3.Database("./test.db");
const createTableQuery = `CREATE TABLE IF NOT EXISTS users (
    id TEXT PRIMARY KEY NOT NULL,
    name TEXT NOT NULL,
    email TEXT NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
)`;
```

How type annotations currently works:
**NOTE**: this will still work after the code changes.
```typescript
const query = "SELECT * FROM users";
db.all(query, [], (err, rows: IUser[]) => {
    if (err) {
        console.error(err.message);
    } else {
        console.log(rows[1].email);
    }
});
```

Now you will be able to:
```typescript
const query = "SELECT * FROM users";
db.all<IUser>(query, [], (err, rows) => {
    if (err) {
        console.error(err.message);
    } else {
        console.log(rows[1].email);
    }
});
```