### PR TITLE
Update dependencies for mocha and node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "eslint": "6.8.0",
-    "mocha": "7.2.0",
+    "mocha": "^10.2.0",
     "node-pre-gyp-github": "1.4.4"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "node-pre-gyp-github": "1.4.4"
   },
   "peerDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": "9.x"
   },
   "peerDependenciesMeta": {
     "node-gyp": {
@@ -66,7 +66,7 @@
     }
   },
   "optionalDependencies": {
-    "node-gyp": "8.x"
+    "node-gyp": "9.x"
   },
   "scripts": {
     "build": "node-pre-gyp build",


### PR DESCRIPTION
There was 1 high and 3 critical vulnerabilities, but by updating mocha to version 10.2.0 and node-gyp 9.x they are fixed