### PR TITLE
Installed setuptools in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
         if: matrix.os == 'macos-m1'
         run: npm install -g yarn
 
+      - name: Add setuptools for Python 3.12 (temp)
+        if: matrix.os != 'macos-m1'
+        run: pip install setuptools
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
         if: contains(matrix.os, 'windows')


### PR DESCRIPTION
- Python 3.12 no longer ships with this and GHA CI has updated to 3.12, which breaks our build scripts
- this should fix that until we can update node-gyp