### PR TITLE
src: precompute field names

### DIFF
--- a/src/statement.h
+++ b/src/statement.h
@@ -220,7 +220,7 @@ protected:
     bool Bind(const Parameters &parameters);
 
     static void GetRow(Row* row, sqlite3_stmt* stmt);
-    static Napi::Value RowToJS(Napi::Env env, Row* row);
+    static Napi::Value RowToJS(Napi::Env env, Row* row, std::vector<napi_value>* js_names = nullptr);
     void Schedule(Work_Callback callback, Baton* baton);
     void Process();
     void CleanQueue();


### PR DESCRIPTION
Field names do not change from row to row, so let's create JS strings only during the process of calling back into JS with the first row, not with each row. We save the JS strings we created while calling back with the first row, and re-use them when creating objects for subsequent rows.

Re: https://github.com/nodejs/abi-stable-node/issues/458