### PR TITLE
Fix: Corrected package.json for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "binary": {
     "napi_versions": [
-      3,
       6
     ]
   },


### PR DESCRIPTION
The current package.json convert the 3,6 array to a N-API 36 that don't exist. 