### PR TITLE
GitHub Actions: Add Ubuntu on ARM to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-20.04
+          - ubuntu-24.04-arm
           - windows-latest
         host:
           - x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-20.04
-          - ubuntu-24.04-arm
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
           - windows-latest
         host:
           - x64


### PR DESCRIPTION
[`runner.arch`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context) will be `ARM64` on both `macos-latest` and `ubuntu-24.04-arm`.

* [GitHub Actions: Detecting the operating system](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system) --> `runner.os` in ["macOS", "Linux", "Windows"]
* [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`